### PR TITLE
fix cli arg parsing

### DIFF
--- a/src/main/java/parsevamath/tools/Main.java
+++ b/src/main/java/parsevamath/tools/Main.java
@@ -64,6 +64,7 @@ public final class Main {
         final CommandLine commandLine = new CommandLine(cliOptions);
         commandLine.setUsageHelpWidth(CliOptions.HELP_WIDTH);
         commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        commandLine.parseArgs(args);
 
         try {
             if (cliOptions.interactiveMode) {


### PR DESCRIPTION
This PR fixes: when removing unused ParseResult variable, failed to leave parseArgs call to parse the command line args.