### PR TITLE
Issue #39: parseva-math should not throw exception in interactive mode

### DIFF
--- a/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
+++ b/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
@@ -99,16 +99,18 @@ public class EvaluateExpressionVisitor extends AbstractMathAstVisitor<Double> {
     Double visit(MethodNode node) {
         final Method mathMethod = node.getFunction();
         Double returnVal = Double.NaN;
-        try {
-            returnVal =
-                (Double) mathMethod.invoke(mathMethod.getClass(), visit(node.getArgument()));
-        }
-        catch (IllegalAccessException | InvocationTargetException exception) {
-            final String infoString = "Failed to invoke method '"
-                + mathMethod.getName()
-                + "' on arguement '"
-                + node.getArgument();
-            Logger.info(infoString, exception);
+        if (mathMethod != null) {
+            try {
+                returnVal =
+                    (Double) mathMethod.invoke(mathMethod.getClass(), visit(node.getArgument()));
+            }
+            catch (IllegalAccessException | InvocationTargetException exception) {
+                final String infoString = "Failed to invoke method '"
+                    + mathMethod.getName()
+                    + "' on arguement '"
+                    + node.getArgument();
+                Logger.info(infoString, exception);
+            }
         }
         return returnVal;
     }


### PR DESCRIPTION
Issue #39: parseva-math should not throw exception in interactive mode, just error message