### PR TITLE
Issue #38: parseva-math should support built in mathematical constants

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -60,6 +60,8 @@ DOCTYPE
 Dpi
 Drawables
 dtds
+EArithmetic
+EFunction
 Ejb
 Ellipsize
 Emtpy

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -575,6 +575,9 @@
                        HashMap, SortedMap, TreeMap, DetailsAST, CheckstyleException,
                        UnsupportedEncodingException, BuildException, ConversionException,
                        FileNotFoundException, TestException, MathParser, MathLexer"/>
+      <!-- parseva-math specific classes -->
+      <property name="excludedClasses" value="ExpressionNode, AdditionNode, ConstantNode,
+      DivisionNode, MethodNode, MultiplicationNode, NegateNode, NumberNode, SubtractionNode"/>
     </module>
     <module name="ClassFanOutComplexity">
       <property name="max" value="25"/>

--- a/src/main/java/parsevamath/tools/AbstractMathAstVisitor.java
+++ b/src/main/java/parsevamath/tools/AbstractMathAstVisitor.java
@@ -93,6 +93,14 @@ public abstract class AbstractMathAstVisitor<T> {
     abstract T visit(NumberNode node);
 
     /**
+     * Visit a constant node.
+     *
+     * @param node constant node to visit
+     * @return the result of calling visit on node
+     */
+    abstract T visit(ConstantNode node);
+
+    /**
      * This method handles the double dispatch of the visit method for
      * each concrete node type.
      *

--- a/src/main/java/parsevamath/tools/ConstantNode.java
+++ b/src/main/java/parsevamath/tools/ConstantNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+/**
+ * A ConstantNode is used to represent a mathematical constant such as pi or e.
+ *
+ */
+public final class ConstantNode extends NumberNode {
+
+    /**
+     * Constructor for ConstantNode class.
+     *
+     * @param value the numerical value of this node
+     */
+    ConstantNode(Double value) {
+        super(value);
+    }
+}

--- a/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
+++ b/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
@@ -127,6 +127,16 @@ public class EvaluateExpressionVisitor extends AbstractMathAstVisitor<Double> {
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation returns the value of this constant.
+     */
+    @Override
+    Double visit(ConstantNode node) {
+        return node.getValue();
+    }
+
+    /**
      * This method handles the double dispatch of the visit method for
      * each concrete node type.
      *
@@ -144,6 +154,7 @@ public class EvaluateExpressionVisitor extends AbstractMathAstVisitor<Double> {
             case "NegateNode" -> visit((NegateNode) node);
             case "MethodNode" -> visit((MethodNode) node);
             case "NumberNode" -> visit((NumberNode) node);
+            case "ConstantNode" -> visit((ConstantNode) node);
             default -> throw new IllegalStateException("Unexpected value: " + node.getClass());
         };
     }

--- a/src/main/java/parsevamath/tools/MathAstBuilder.java
+++ b/src/main/java/parsevamath/tools/MathAstBuilder.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.antlr.v4.runtime.Token;
 import org.tinylog.Logger;
@@ -169,6 +170,25 @@ public class MathAstBuilder extends MathBaseVisitor<ExpressionNode> {
     @Override
     public ExpressionNode visitNumberExpr(MathParser.NumberExprContext ctx) {
         return new NumberNode(Double.parseDouble(ctx.value.getText()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation instantiates and initializes a new ConstantNode.
+     *
+     * @param ctx rule context
+     * @return new ConstantNode
+     */
+    @Override
+    public ExpressionNode visitConstExpr(MathParser.ConstExprContext ctx) {
+        final Double value = switch (ctx.getText().toUpperCase(Locale.ROOT)) {
+            case "E" -> Math.E;
+            case "PI" -> Math.PI;
+            default -> throw new IllegalStateException("Unexpected value: "
+                + ctx.getText().toUpperCase(Locale.ROOT));
+        };
+        return new ConstantNode(value);
     }
 
     /**

--- a/src/main/resources/parsevamath/tools/grammar/Math.g4
+++ b/src/main/resources/parsevamath/tools/grammar/Math.g4
@@ -15,6 +15,12 @@ expr
     |   left=expr op=( OP_ADD | OP_SUB ) right=expr    # infixExpr
     |   func=ID '(' expr (COMMA expr)* ')'                 # funcExpr
     |   value=NUM                            # numberExpr
+    |   constant                            #constExpr
+    ;
+
+constant
+    :   ( 'e' | 'E' )
+    |   ( 'pi' | 'PI' )
     ;
 
 OP_ADD: '+';

--- a/src/test/java/parsevamath/tools/ConstantTest.java
+++ b/src/test/java/parsevamath/tools/ConstantTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ConstantTest {
+
+    @Test
+    void testE() {
+        final String expression = "e";
+        final Double expected = Math.E;
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @Test
+    void testEArithmetic() {
+        final String expression = "e + E";
+        final Double expected = Math.E + Math.E;
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @Test
+    void testEFunction() {
+        final String expression = "log(e)";
+        final Double expected = StrictMath.log(Math.E);
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @Test
+    void testPI() {
+        final String expression = "pi";
+        final Double expected = Math.PI;
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @Test
+    void testPIArithmetic() {
+        final String expression = "pi + PI";
+        final Double expected = Math.PI + Math.PI;
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+
+    @Test
+    void testPIFunction() {
+        final String expression = "sin(pi)";
+        final Double expected = StrictMath.sin(Math.PI);
+        final Double actual = Main.evaluate(expression);
+        assertThat(expected).isEqualTo(actual);
+    }
+}


### PR DESCRIPTION
Issue #38: parseva-math should support built in mathematical constants