### PR TITLE
Issue #61: parseva-math should print ast

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -181,6 +181,7 @@ lexer
 LHSOf
 listenablefuture
 LNOT
+lparen
 ltrzesniewski
 markdownguide
 matchxpath
@@ -227,6 +228,7 @@ pmd
 png
 Pointcut
 Postgresql
+postion
 powermock
 printf
 println
@@ -244,6 +246,7 @@ regex
 regexp
 Rethrown
 Rgb
+rparen
 Rtl
 rx
 Sameline
@@ -266,6 +269,7 @@ stackoverflow
 Standalone
 Stdlib
 streamapi
+stringbuilders
 Styleable
 Subpackages
 svg

--- a/src/main/java/parsevamath/tools/AbstractMathAstVisitor.java
+++ b/src/main/java/parsevamath/tools/AbstractMathAstVisitor.java
@@ -101,20 +101,33 @@ public abstract class AbstractMathAstVisitor<T> {
     abstract T visit(ConstantNode node);
 
     /**
-     * This method handles the double dispatch of the visit method for
-     * each concrete node type.
-     *
-     * @param node ExpressionNode to visit
-     * @return the result of calling visit on node
-     * @noinspection OverloadedMethodsWithSameNumberOfParameters
-     */
-    abstract T visit(ExpressionNode node);
-
-    /**
      * Visit a factorial node.
      *
      * @param node factorial node to visit
      * @return the result of calling visit on node
      */
     abstract T visit(FactorialNode node);
+
+    /**
+     * This method handles the double dispatch of the visit method for
+     * each concrete node type.
+     *
+     * @param node the expression node to process
+     * @return the result of calling visit on node
+     * @throws IllegalStateException on unknown token
+     */
+    public T visit(ExpressionNode node) {
+        return switch (node.getClass().getSimpleName()) {
+            case "AdditionNode" -> visit((AdditionNode) node);
+            case "SubtractionNode" -> visit((SubtractionNode) node);
+            case "MultiplicationNode" -> visit((MultiplicationNode) node);
+            case "DivisionNode" -> visit((DivisionNode) node);
+            case "NegateNode" -> visit((NegateNode) node);
+            case "MethodNode" -> visit((MethodNode) node);
+            case "NumberNode" -> visit((NumberNode) node);
+            case "ConstantNode" -> visit((ConstantNode) node);
+            case "FactorialNode" -> visit((FactorialNode) node);
+            default -> throw new IllegalStateException("Unexpected value: " + node.getClass());
+        };
+    }
 }

--- a/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
+++ b/src/main/java/parsevamath/tools/EvaluateExpressionVisitor.java
@@ -147,27 +147,4 @@ public class EvaluateExpressionVisitor extends AbstractMathAstVisitor<Double> {
         return node.getValue();
     }
 
-    /**
-     * This method handles the double dispatch of the visit method for
-     * each concrete node type.
-     *
-     * @param node the expression node to process
-     * @return the result of calling visit on node
-     * @throws IllegalStateException on unknown token
-     */
-    @Override
-    public Double visit(ExpressionNode node) {
-        return switch (node.getClass().getSimpleName()) {
-            case "AdditionNode" -> visit((AdditionNode) node);
-            case "SubtractionNode" -> visit((SubtractionNode) node);
-            case "MultiplicationNode" -> visit((MultiplicationNode) node);
-            case "DivisionNode" -> visit((DivisionNode) node);
-            case "NegateNode" -> visit((NegateNode) node);
-            case "MethodNode" -> visit((MethodNode) node);
-            case "NumberNode" -> visit((NumberNode) node);
-            case "ConstantNode" -> visit((ConstantNode) node);
-            case "FactorialNode" -> visit((FactorialNode) node);
-            default -> throw new IllegalStateException("Unexpected value: " + node.getClass());
-        };
-    }
 }

--- a/src/main/java/parsevamath/tools/HomogeneousAstVisitor.java
+++ b/src/main/java/parsevamath/tools/HomogeneousAstVisitor.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import java.util.List;
+
+import org.antlr.v4.runtime.Token;
+
+import parsevamath.tools.grammar.MathBaseVisitor;
+import parsevamath.tools.grammar.MathLexer;
+import parsevamath.tools.grammar.MathParser;
+
+/**
+ * This visitor traverses the antlr-parsed rule contexts and builds
+ * an AST.
+ */
+public class HomogeneousAstVisitor
+    extends MathBaseVisitor<MathAstNode> implements HomogeneousAstVisitorInterface {
+
+    /**
+     * This string is used when throwing IllegalStateException on an
+     * unknown token.
+     */
+    private static final String UNEXPECTED_TOKEN = "Unexpected token: ";
+
+    /**
+     * Start the tree, root node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitCompilationUnit(MathParser.CompilationUnitContext ctx) {
+        return visit(ctx.expr());
+    }
+
+    /**
+     * Build infix expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitInfixExpr(MathParser.InfixExprContext ctx) {
+        final Token token = ctx.op;
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.op.getText());
+        final int tokenType = switch (token.getType()) {
+            case MathLexer.OP_ADD -> TokenTypes.OP_ADD;
+            case MathLexer.OP_SUB -> TokenTypes.OP_SUB;
+            case MathLexer.OP_MUL -> TokenTypes.OP_MUL;
+            case MathLexer.OP_DIV -> TokenTypes.OP_DIV;
+            default -> throw new IllegalStateException(UNEXPECTED_TOKEN
+                + token.getType());
+        };
+        astNode.setTokenType(tokenType);
+        astNode.addChild(visit(ctx.left));
+        astNode.addChild(visit(ctx.right));
+
+        astNode.getChildren()
+            .forEach(child -> child.setParent(astNode));
+        return astNode;
+    }
+
+    /**
+     * Build unary expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitUnaryExpr(MathParser.UnaryExprContext ctx) {
+        final Token token = ctx.op;
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.getText());
+        final int tokenType = switch (token.getType()) {
+            case MathLexer.OP_ADD -> TokenTypes.OP_ADD;
+            case MathLexer.OP_SUB -> TokenTypes.NEGATE;
+            default -> throw new IllegalStateException(UNEXPECTED_TOKEN
+                + token.getType());
+        };
+        astNode.setTokenType(tokenType);
+        astNode.addChild(visit(ctx.expr()));
+        astNode.getChildren()
+            .forEach(child -> child.setParent(astNode));
+        return astNode;
+    }
+
+    /**
+     * Non-terminal node for tree structure.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitFuncExpr(MathParser.FuncExprContext ctx) {
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.func.getText());
+        astNode.setTokenType(TokenTypes.FUNCTION);
+
+        final List<MathParser.ExprContext> exprContexts = ctx.expr();
+        exprContexts.forEach(exprContext -> {
+            final MathAstNode childNode = new MathAstNode();
+            childNode.setText(exprContext.getText());
+            childNode.setTokenType(TokenTypes.NUM);
+            astNode.addChild(childNode);
+        });
+
+        return astNode;
+    }
+
+    /**
+     * Build numerical expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitNumberExpr(MathParser.NumberExprContext ctx) {
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.getText());
+        astNode.setTokenType(TokenTypes.NUM);
+        return astNode;
+    }
+
+    /**
+     * Build the root of a parenthesis expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitParensExpr(MathParser.ParensExprContext ctx) {
+        final MathAstNode leftParen = new MathAstNode();
+        leftParen.setText(ctx.lparen.getText());
+        leftParen.setTokenType(TokenTypes.LPAREN);
+        leftParen.addChild(visit(ctx.expr()));
+
+        final MathAstNode rightParen = new MathAstNode();
+        rightParen.setText(ctx.rparen.getText());
+        rightParen.setTokenType(TokenTypes.RPAREN);
+        leftParen.addChild(rightParen);
+
+        leftParen.getChildren().forEach(child -> {
+            child.setParent(leftParen);
+        });
+
+        return leftParen;
+    }
+
+    /**
+     * Build a factorial expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitFactorialExpr(MathParser.FactorialExprContext ctx) {
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.fact.getText());
+        astNode.setTokenType(TokenTypes.FACTORIAL);
+        astNode.addChild(visit(ctx.expr()));
+        return astNode;
+    }
+
+    /**
+     * Help build a constant expression node, this is non-terminal.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitConstExpr(MathParser.ConstExprContext ctx) {
+        return visit(ctx.constant());
+    }
+
+    /**
+     * Build the concrete constant expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    @Override
+    public MathAstNode visitConstant(MathParser.ConstantContext ctx) {
+        final MathAstNode astNode = new MathAstNode();
+        astNode.setText(ctx.getText());
+        astNode.setTokenType(TokenTypes.CONSTANT);
+        return astNode;
+    }
+}

--- a/src/main/java/parsevamath/tools/HomogeneousAstVisitorInterface.java
+++ b/src/main/java/parsevamath/tools/HomogeneousAstVisitorInterface.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+
+import parsevamath.tools.grammar.MathParser;
+
+/**
+ * A ast visitor, used for constructing a homogeneous ast.
+ */
+public interface HomogeneousAstVisitorInterface extends ParseTreeVisitor<MathAstNode> {
+
+    /**
+     * Start the tree, root node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitCompilationUnit(MathParser.CompilationUnitContext ctx);
+
+    /**
+     * Build infix expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitInfixExpr(MathParser.InfixExprContext ctx);
+
+    /**
+     * Build unary expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitUnaryExpr(MathParser.UnaryExprContext ctx);
+
+    /**
+     * Non-terminal node for tree structure.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitFuncExpr(MathParser.FuncExprContext ctx);
+
+    /**
+     * Build numerical expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitNumberExpr(MathParser.NumberExprContext ctx);
+
+    /**
+     * Build the root of a parenthesis expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitParensExpr(MathParser.ParensExprContext ctx);
+
+    /**
+     * Build a factorial expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitFactorialExpr(MathParser.FactorialExprContext ctx);
+
+    /**
+     * Help build a constant expression node, this is non-terminal.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitConstExpr(MathParser.ConstExprContext ctx);
+
+    /**
+     * Build the concrete constant expression node.
+     *
+     * @param ctx context to analyze
+     * @return MathAstNode tree
+     */
+    MathAstNode visitConstant(MathParser.ConstantContext ctx);
+}

--- a/src/main/java/parsevamath/tools/Main.java
+++ b/src/main/java/parsevamath/tools/Main.java
@@ -79,6 +79,10 @@ public final class Main {
             else if (commandLine.isVersionHelpRequested()) {
                 System.out.println(ParsevaUtils.getParsevaVersion());
             }
+            else if (cliOptions.treeMode) {
+                final MathAstNode root = buildMathAstNodeTree(cliOptions.expression);
+                System.out.println(ParsevaUtils.toStringTree(root));
+            }
             else {
                 commandLine.usage(System.out);
             }
@@ -128,6 +132,21 @@ public final class Main {
     }
 
     /**
+     * Builds the Math AST.
+     *
+     * @param exprInput the expression to evaluate and build AST for.
+     * @return MathNodeAst of expression
+     */
+    public static MathAstNode buildMathAstNodeTree(String exprInput) {
+        final CharStream codePointCharStream = CharStreams.fromString(exprInput);
+        final MathLexer lexer = new MathLexer(codePointCharStream);
+        final CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        final MathParser parser = new MathParser(tokenStream);
+        final MathParser.CompilationUnitContext compilationUnit = parser.compilationUnit();
+        return new HomogeneousAstVisitor().visit(compilationUnit);
+    }
+
+    /**
      * Handles printing of output.
      *
      * @param value the double to print
@@ -172,9 +191,21 @@ public final class Main {
             "--evaluate"
         },
             description = "Evaluation mode. This option evaluates the given expression,"
-                + " and returns the result.",
+                + " and returns the result. Example: '-e \" 2 + 2\"'",
             defaultValue = "false")
         private boolean evaluationMode;
+
+        /**
+         * This boolean value determines if user wants to print expression AST.
+         */
+        @Option(names = {
+            "-t",
+            "--tree"
+        },
+            description = "Tree mode. This option builds an AST of the given expression,"
+                + " and prints the result. Example: '-t \"2 + 2\"'",
+            defaultValue = "false")
+        private boolean treeMode;
 
         /**
          * The actual expression we are evaluating.

--- a/src/main/java/parsevamath/tools/MathAstBuilder.java
+++ b/src/main/java/parsevamath/tools/MathAstBuilder.java
@@ -44,7 +44,8 @@ import parsevamath.tools.grammar.MathParser;
 /**
  * This class builds an ast for parseva-math grammar using the visitor pattern.
  */
-public class MathAstBuilder extends MathBaseVisitor<ExpressionNode> {
+public class MathAstBuilder
+    extends MathBaseVisitor<ExpressionNode> implements MathAstBuilderInterface {
 
     /**
      * This string is used when throwing IllegalStateException on an

--- a/src/main/java/parsevamath/tools/MathAstBuilderInterface.java
+++ b/src/main/java/parsevamath/tools/MathAstBuilderInterface.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+
+import parsevamath.tools.grammar.MathParser;
+
+/**
+ * This interface defines the operations on antlr-parsed rule contexts.
+ */
+public interface MathAstBuilderInterface extends ParseTreeVisitor<ExpressionNode> {
+
+    /**
+     * Evaluate the tree.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated tree
+     */
+    ExpressionNode visitCompilationUnit(MathParser.CompilationUnitContext ctx);
+
+    /**
+     * Evaluate an infix expression.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated expression
+     */
+    ExpressionNode visitInfixExpr(MathParser.InfixExprContext ctx);
+
+    /**
+     * Evaluate a unary expression.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated expression
+     */
+    ExpressionNode visitUnaryExpr(MathParser.UnaryExprContext ctx);
+
+    /**
+     * Evaluate a function node with args.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated function
+     */
+    ExpressionNode visitFuncExpr(MathParser.FuncExprContext ctx);
+
+    /**
+     * Return a numerical value from AST.
+     *
+     * @param ctx rule context to analyze
+     * @return numerical value
+     */
+    ExpressionNode visitNumberExpr(MathParser.NumberExprContext ctx);
+
+    /**
+     * Return a constant expression.
+     *
+     * @param ctx rule context to analyze
+     * @return constant
+     */
+    ExpressionNode visitConstExpr(MathParser.ConstExprContext ctx);
+
+    /**
+     * Evaluate a parenthetical expression.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated parenthetical expression
+     */
+    ExpressionNode visitParensExpr(MathParser.ParensExprContext ctx);
+
+    /**
+     * Evaluate a factorial node.
+     *
+     * @param ctx rule context to analyze
+     * @return evaluated factorial
+     */
+    ExpressionNode visitFactorialExpr(MathParser.FactorialExprContext ctx);
+}

--- a/src/main/java/parsevamath/tools/MathAstNode.java
+++ b/src/main/java/parsevamath/tools/MathAstNode.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The node type used in the homogeneous abstract syntax tree.
+ */
+public class MathAstNode {
+
+    /**
+     * Token type of this MathAstNode.
+     */
+    private int tokenType;
+
+    /**
+     * Children of this MathAstNode.
+     */
+    private List<MathAstNode> children;
+
+    /**
+     * Position of this MathAstNode in expression.
+     */
+    private int columnNumber;
+
+    /**
+     * The parent MathAstNode of this MathAstNode.
+     */
+    private MathAstNode parent;
+
+    /**
+     * The text of this MathAstNode.
+     */
+    private String text;
+
+    /**
+     * Default constructor.
+     */
+    public MathAstNode() {
+        children = new ArrayList<>();
+    }
+
+    /**
+     * Get the parent node of this node.
+     *
+     * @return the parent of this node
+     */
+    public final MathAstNode getParent() {
+        return parent;
+    }
+
+    /**
+     * Set the parent node of this node.
+     *
+     * @param parent the MathAstNode to set
+     */
+    public void setParent(MathAstNode parent) {
+        this.parent = parent;
+    }
+
+    /**
+     * Adds one child to the child list of this MathAstNode.
+     *
+     * @param node the MathAstNode to add
+     */
+    public void addChild(MathAstNode node) {
+        children.add(node);
+    }
+
+    /**
+     * Get the text of this node.
+     *
+     * @return string of text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Set the text of this MathAstNode.
+     *
+     * @param text to be set
+     */
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Gets type of this MathAstNode.
+     *
+     * @return type of node
+     */
+    public int getTokenType() {
+        return tokenType;
+    }
+
+    /**
+     * Sets token type of this node.
+     *
+     * @param tokenType the type of token to set
+     */
+    public void setTokenType(int tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    /**
+     * Get an unmodifiable list of children from this MathAstNode.
+     *
+     * @return unmodifiable list
+     */
+    public List<MathAstNode> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
+
+    /**
+     * Sets the children of this MathAstNode.
+     *
+     * @param children list of children
+     */
+    public void setChildren(List<MathAstNode> children) {
+        this.children = Collections.unmodifiableList(children);
+    }
+
+    /**
+     * Gets position of this token.
+     *
+     * @return index of token in line
+     */
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+
+    /**
+     * Sets the column number of this token.
+     *
+     * @param columnNumber sets postion of token.
+     */
+    public void setColumnNumber(int columnNumber) {
+        this.columnNumber = columnNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "MathAstNode{" + "tokenType=" + tokenType
+            + ", children=" + children
+            + ", columnNumber=" + columnNumber
+            + ", parent=" + parent
+            + ", text='" + text + '\''
+            + '}';
+    }
+}

--- a/src/main/java/parsevamath/tools/MathUtils.java
+++ b/src/main/java/parsevamath/tools/MathUtils.java
@@ -33,6 +33,9 @@ package parsevamath.tools;
  */
 public final class MathUtils {
 
+    /**
+     * Prevent instantiation.
+     */
     private MathUtils() {
     }
 

--- a/src/main/java/parsevamath/tools/ParsevaUtils.java
+++ b/src/main/java/parsevamath/tools/ParsevaUtils.java
@@ -30,6 +30,8 @@ package parsevamath.tools;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.tinylog.Logger;
@@ -39,8 +41,15 @@ import org.tinylog.Logger;
  */
 public final class ParsevaUtils {
 
+    /**
+     * Capacity for stringbuilders.
+     */
+    public static final int CAPACITY = 1024;
+
+    /**
+     * Prevent instantiation.
+     */
     private ParsevaUtils() {
-        // Prevent instantiation of parsevamath.tools.MathUtils
     }
 
     /**
@@ -89,4 +98,67 @@ public final class ParsevaUtils {
 
         return versionString;
     }
+
+    /**
+     * Builds a string representation of the ast.
+     *
+     * @param astNode the ast node to build string of
+     * @return string representation of ast
+     */
+    public static String toStringTree(MathAstNode astNode) {
+        MathAstNode ast = astNode;
+        final List<MathAstNode> firstStack = new ArrayList<>();
+        firstStack.add(ast);
+
+        final List<List<MathAstNode>> childListStack = new ArrayList<>();
+        childListStack.add(firstStack);
+
+        final StringBuilder builder = new StringBuilder(CAPACITY);
+        while (!childListStack.isEmpty()) {
+
+            final List<MathAstNode> childStack = childListStack.get(childListStack.size() - 1);
+
+            if (childStack.isEmpty()) {
+                childListStack.remove(childListStack.size() - 1);
+            }
+            else {
+                ast = childStack.remove(0);
+
+                final String caption = String.format("%s -> %s",
+                    TokenUtil.getTokenName(ast.getTokenType()), ast.getText());
+
+                final StringBuilder indent = new StringBuilder(CAPACITY);
+
+                for (int i = 0; i < childListStack.size() - 1; i++) {
+                    if (childListStack.get(i).isEmpty()) {
+                        indent.append("   ");
+                    }
+                    else {
+                        indent.append("|  ");
+                    }
+                }
+
+                if (childStack.isEmpty()) {
+                    builder.append(indent)
+                        .append("'- ")
+                        .append(caption)
+                        .append(System.lineSeparator());
+                }
+                else {
+                    builder.append(indent)
+                        .append("|- ")
+                        .append(caption)
+                        .append(System.lineSeparator());
+                }
+
+                if (ast.getChildren().isEmpty()) {
+                    continue;
+                }
+                final List<MathAstNode> toStringChildren = new ArrayList<>(ast.getChildren());
+                childListStack.add(toStringChildren);
+            }
+        }
+        return builder.toString();
+    }
+
 }

--- a/src/main/java/parsevamath/tools/TokenTypes.java
+++ b/src/main/java/parsevamath/tools/TokenTypes.java
@@ -32,43 +32,73 @@ package parsevamath.tools;
  * This class is used to decouple the token types from the generated ANTLR
  * code.
  */
-public final class MathTokenTypes {
+public final class TokenTypes {
 
     /**
      * This token is the addition operator.
      */
-    public static final int OP_ADD = 3;
+    public static final int OP_ADD = 0;
 
     /**
      * This token is the subtraction operator.
      */
-    public static final int OP_SUB = 4;
+    public static final int OP_SUB = 1;
 
     /**
      * This token is the multiplication operator.
      */
-    public static final int OP_MUL = 5;
+    public static final int OP_MUL = 2;
 
     /**
      * This token is the division operator.
      */
-    public static final int OP_DIV = 6;
+    public static final int OP_DIV = 3;
 
     /**
      * This token is a numerical expression.
      */
-    public static final int NUM = 7;
+    public static final int NUM = 4;
 
     /**
      * This token is an identifier.
      */
-    public static final int ID = 8;
+    public static final int ID = 5;
 
     /**
      * This token is for whitespace.
      */
-    public static final int WS = 9;
+    public static final int WS = 6;
 
-    private MathTokenTypes() {
+    /**
+     * This is the negation node token.
+     */
+    public static final int NEGATE = 7;
+
+    /**
+     * This is the method (function) node token.
+     */
+    public static final int FUNCTION = 8;
+
+    /**
+     * This is the constant node token.
+     */
+    public static final int CONSTANT = 9;
+
+    /**
+     * This is the factorial node token.
+     */
+    public static final int FACTORIAL = 10;
+
+    /**
+     * This is the factorial node token.
+     */
+    public static final int LPAREN = 11;
+
+    /**
+     * This is the factorial node token.
+     */
+    public static final int RPAREN = 12;
+
+    private TokenTypes() {
     }
 }

--- a/src/main/java/parsevamath/tools/TokenUtil.java
+++ b/src/main/java/parsevamath/tools/TokenUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+/**
+ * This utility class handles token-related tasks.
+ */
+public final class TokenUtil {
+
+    /**
+     * Maps from a token value to name.
+     */
+    private static final String[] TOKEN_VALUE_TO_NAME;
+
+    static {
+
+        // These tokens MUST be in the same order as the declared fields of
+        // TokenTypes.
+        TOKEN_VALUE_TO_NAME = new String[] {
+            "OP_ADD", "OP_SUB", "OP_MUL", "OP_DIV",
+            "NUM", "ID", "WS", "NEGATE", "FUNCTION",
+            "CONSTANT", "FACTORIAL", "LPAREN",
+            "RPAREN",
+        };
+    }
+
+    /**
+     * Prevent instantiation.
+     */
+    private TokenUtil() {
+    }
+
+    /**
+     * Returns the name of a token for a given ID.
+     *
+     * @param id the ID of the token name to get
+     * @return a token name
+     * @throws IllegalArgumentException when id is not valid
+     */
+    public static String getTokenName(int id) {
+        if (id > TOKEN_VALUE_TO_NAME.length - 1) {
+            throw new IllegalArgumentException(
+                "Token value is greater than number of tokens!");
+        }
+        final String name = TOKEN_VALUE_TO_NAME[id];
+        if (name == null) {
+            throw new IllegalArgumentException("Token name is not assigned!");
+        }
+        return name;
+    }
+
+    /**
+     * Gets the number of named tokens in
+     * 'TOKEN_VALUE_TO_NAME' array.
+     *
+     * @return number of token names
+     */
+    public static int getNumberOfTokenNames() {
+        return TOKEN_VALUE_TO_NAME.length;
+    }
+
+    /**
+     * Gets entire contents of 'TOKEN_VALUE_TO_NAME'.
+     *
+     * @return all token names
+     */
+    public static String[] getAllTokenNames() {
+        return TOKEN_VALUE_TO_NAME;
+    }
+}

--- a/src/main/resources/parsevamath/tools/grammar/Math.g4
+++ b/src/main/resources/parsevamath/tools/grammar/Math.g4
@@ -9,14 +9,14 @@ compilationUnit
     ;
 
 expr
-    :   '(' expr ')'                         # parensExpr
+    :   lparen=LPAREN expr rparen=RPAREN                         # parensExpr
     |   op=( OP_ADD | OP_SUB ) expr                    # unaryExpr
     |   left=expr op=( OP_MUL | OP_DIV ) right=expr    # infixExpr
     |   left=expr op=( OP_ADD | OP_SUB ) right=expr    # infixExpr
     |   func=ID '(' expr (COMMA expr)* ')'                 # funcExpr
     |   value=NUM                            # numberExpr
     |   constant                            #constExpr
-    |   expr OP_FACT                        #factorialExpr
+    |   expr fact=OP_FACT                        #factorialExpr
     ;
 
 constant
@@ -29,6 +29,8 @@ OP_SUB: '-';
 OP_MUL: '*';
 OP_DIV: '/';
 OP_FACT: '!';
+LPAREN: '(';
+RPAREN: ')';
 
 NUM :   [0-9]+ ('.' [0-9]+)? ([eE] [+-]? [0-9]+)?;
 ID  :   [a-zA-Z]+;

--- a/src/test/java/parsevamath/tools/HomogeneousAstTest.java
+++ b/src/test/java/parsevamath/tools/HomogeneousAstTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class HomogeneousAstTest {
+
+    @Test
+    void testBasicAst() {
+        final String expression = "2 + 2 * 4";
+        final String expected = """
+            '- OP_ADD -> +
+               |- NUM -> 2
+               '- OP_MUL -> *
+                  |- NUM -> 2
+                  '- NUM -> 4
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testConstExpressionAst() {
+        final String expression = "2 * e";
+        final String expected = """
+            '- OP_MUL -> *
+               |- NUM -> 2
+               '- CONSTANT -> e
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testFunctionExpressionAst() {
+        final String expression = "2 + sqrt(4)";
+        final String expected = """
+            '- OP_ADD -> +
+               |- NUM -> 2
+               '- FUNCTION -> sqrt
+                  '- NUM -> 4
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testFactorialExpressionAst() {
+        final String expression = "5!";
+        final String expected = """
+            '- FACTORIAL -> !
+               '- NUM -> 5
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testNumber() {
+        final String expression = "22";
+        final String expected = """
+            '- NUM -> 22
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testTwoArgFunction() {
+        final String expression = "pow(2.0,2.0)";
+        final String expected = """
+            '- FUNCTION -> pow
+               |- NUM -> 2.0
+               '- NUM -> 2.0
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testParenFactorial() {
+        final String expression = "(5 + 1)!";
+        final String expected = """
+            '- FACTORIAL -> !
+               '- LPAREN -> (
+                  |- OP_ADD -> +
+                  |  |- NUM -> 5
+                  |  '- NUM -> 1
+                  '- RPAREN -> )
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+
+    @Test
+    void testParenExpression() {
+        final String expression = "(2 + 5) + sin(2.5)";
+        final String expected = """
+            '- OP_ADD -> +
+               |- LPAREN -> (
+               |  |- OP_ADD -> +
+               |  |  |- NUM -> 2
+               |  |  '- NUM -> 5
+               |  '- RPAREN -> )
+               '- FUNCTION -> sin
+                  '- NUM -> 2.5
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testComplicated() {
+        final String expression = "2 + sin(1.24) + sqrt(5) + "
+            + "pow(4,4) * 22 + sqrt(9)";
+        final String expected = """
+            '- OP_ADD -> +
+               |- OP_ADD -> +
+               |  |- OP_ADD -> +
+               |  |  |- OP_ADD -> +
+               |  |  |  |- NUM -> 2
+               |  |  |  '- FUNCTION -> sin
+               |  |  |     '- NUM -> 1.24
+               |  |  '- FUNCTION -> sqrt
+               |  |     '- NUM -> 5
+               |  '- OP_MUL -> *
+               |     |- FUNCTION -> pow
+               |     |  |- NUM -> 4
+               |     |  '- NUM -> 4
+               |     '- NUM -> 22
+               '- FUNCTION -> sqrt
+                  '- NUM -> 9
+            """;
+        final String actual =
+            ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+
+}

--- a/src/test/java/parsevamath/tools/TokenTest.java
+++ b/src/test/java/parsevamath/tools/TokenTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) parseva-math  2021.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ */
+
+package parsevamath.tools;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class TokenTest {
+
+    @Test
+    void testTokenNumber() {
+        final int numberOfTokenNames =
+            TokenUtil.getNumberOfTokenNames();
+        final int numberOfTokenTypes =
+            TokenTypes.class.getDeclaredFields().length;
+        final String message = """
+        Number of token types in MathTokenTypes.java and 
+        token names in MathTokenUtil.java do not match.
+        """;
+        assertWithMessage(message)
+            .that(numberOfTokenNames)
+            .isEqualTo(numberOfTokenTypes);
+    }
+
+    @Test
+    void testTokenNamesOrder() {
+        final Field[] mathTokenTypesFields = TokenTypes.class.getDeclaredFields();
+        Stream<Field> stream = Arrays.stream(mathTokenTypesFields);
+        final String[] mathTokenTypesNames = stream
+            .map(Field::getName)
+            .toArray(String[]::new);
+        final String [] mathTokenUtilNames = TokenUtil.getAllTokenNames();
+        final String message = """
+            Names of token types in MathTokenTypes.java and 
+            token names in MathTokenUtil.java are not in the same
+            order.
+            """;
+
+        assertWithMessage(message)
+            .that(mathTokenTypesNames)
+            .isEqualTo(mathTokenUtilNames);
+    }
+}


### PR DESCRIPTION
Issue #61: parseva-math should print ast.  This PR implements this feature using a homogeneous AST node called MathAstNode.