### PR TITLE
Issue #70: parseva-math should include comma in AST

### DIFF
--- a/src/main/java/parsevamath/tools/HomogeneousAstVisitor.java
+++ b/src/main/java/parsevamath/tools/HomogeneousAstVisitor.java
@@ -28,9 +28,11 @@
 
 package parsevamath.tools;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import parsevamath.tools.grammar.MathBaseVisitor;
 import parsevamath.tools.grammar.MathLexer;
@@ -133,16 +135,23 @@ public class HomogeneousAstVisitor
         astNode.addChild(leftParen);
 
         final List<MathParser.ExprContext> exprContexts = ctx.expr();
+        final Iterator<TerminalNode> commaNodes = ctx.COMMA().iterator();
         exprContexts.forEach(exprContext -> {
             astNode.addChild(visit(exprContext));
-        });
 
-        astNode.getChildren().forEach(child -> child.setParent(astNode));
+            if (commaNodes.hasNext()) {
+                final MathAstNode commaNode = new MathAstNode();
+                commaNode.setText(commaNodes.next().getText());
+                commaNode.setTokenType(TokenTypes.COMMA);
+                astNode.addChild(commaNode);
+            }
+        });
 
         final MathAstNode rightParen = new MathAstNode();
         rightParen.setText(ctx.rparen.getText());
         rightParen.setTokenType(TokenTypes.RPAREN);
         astNode.addChild(rightParen);
+        astNode.getChildren().forEach(child -> child.setParent(astNode));
 
         return astNode;
     }

--- a/src/test/java/parsevamath/tools/HomogeneousAstTest.java
+++ b/src/test/java/parsevamath/tools/HomogeneousAstTest.java
@@ -108,6 +108,7 @@ public class HomogeneousAstTest {
             '- FUNCTION -> pow
                |- LPAREN -> (
                |- NUM -> 2.0
+               |- COMMA -> ,
                |- NUM -> 2.0
                '- RPAREN -> )
             """;
@@ -175,6 +176,7 @@ public class HomogeneousAstTest {
                |     |- FUNCTION -> pow
                |     |  |- LPAREN -> (
                |     |  |- NUM -> 4
+               |     |  |- COMMA -> ,
                |     |  |- NUM -> 4
                |     |  '- RPAREN -> )
                |     '- NUM -> 22
@@ -208,6 +210,7 @@ public class HomogeneousAstTest {
                |     |  '- FUNCTION -> pow
                |     |     |- LPAREN -> (
                |     |     |- NUM -> 5
+               |     |     |- COMMA -> ,
                |     |     |- NUM -> 2
                |     |     '- RPAREN -> )
                |     '- RPAREN -> )
@@ -217,7 +220,4 @@ public class HomogeneousAstTest {
             ParsevaUtils.toStringTree(Main.buildMathAstNodeTree(expression));
         assertThat(actual).isEqualTo(expected);
     }
-
-
-
 }


### PR DESCRIPTION
Issue #70: parseva-math should include comma in AST